### PR TITLE
Feature/commit 15

### DIFF
--- a/src/main/java/org/gbif/ipt/config/Constants.java
+++ b/src/main/java/org/gbif/ipt/config/Constants.java
@@ -15,6 +15,7 @@ public final class Constants {
   public static final String SESSION_FILE_NAME = "fileName";
   public static final String SESSION_FILE_CONTENT_TYPE = "contentType";
   public static final String SESSION_FILE_NUMBER_COLUMNS = "numberColumns";
+  public static final String HUMBOLDT_MAIL_DOMAIN = "@humboldt.org.co";
   public static final String REQ_PATH_RESOURCE = "resource";
   public static final String REQ_PATH_EML = "eml.do";
   public static final String REQ_PATH_DWCA = "archive.do";

--- a/src/main/java/org/gbif/ipt/service/manage/impl/ResourceManagerImpl.java
+++ b/src/main/java/org/gbif/ipt/service/manage/impl/ResourceManagerImpl.java
@@ -974,7 +974,7 @@ public class ResourceManagerImpl extends BaseManager implements ResourceManager,
 
   public List<Resource> list(User user) {
     List<Resource> result = new ArrayList<Resource>();
-    // select basedon user rights - for testing return all resources for now
+    // select based on user rights - for testing return all resources for now
     for (Resource res : resources.values()) {
       if (RequireManagerInterceptor.isAuthorized(user, res)) {
         result.add(res);

--- a/src/main/resources/ApplicationResources_es.properties
+++ b/src/main/resources/ApplicationResources_es.properties
@@ -1352,7 +1352,7 @@ eml.intellectualRights.license.disclaimer=Debe aplicar la licencia CC0 solamente
 eml.intellectualRights.license.text.externalInternal=Libre a nivel externo e interno
 eml.intellectualRights.license.text.internal=Libre a nivel interno
 eml.intellectualRights.license.text.internalNotification=Libre a nivel interno con notificación previa
-eml.intellectualRights.license.text.temporalRestriction=Restricción temporal
+eml.intellectualRights.license.text.temporalRestriction=Restringido temporalmente
 
 eml.updateFrequency=Frecuencia de actualización
 eml.updateFrequency.help=La frecuencia con la que se realizan cambios en el recurso luego de que el recurso inicial ha sido publicado. Para su comodidad, este valor se asignará por defecto para el intervalo de la autopublicación (si se ha activado la autopublicación), sin embargo, este puede ser modificado posteriormente. Por favor tenga en cuenta que una descripción de la frecuencia de mantenimiento del recurso también se pueden documentar en la sección de Metadatos Adicionales.

--- a/src/main/webapp/WEB-INF/pages/admin/user.ftl
+++ b/src/main/webapp/WEB-INF/pages/admin/user.ftl
@@ -60,30 +60,69 @@
                     <#if "${newUser!}"=="no">
                         </br></br>
                         <select multiple="multiple" id="user.grantAccessTo" name="user.grantAccessTo">
-                            <#if restrictedResources?has_content>
-                                <#list restrictedResources?sort_by("shortname") as rR>
-                                    <option value='${rR.shortname}'>${rR.shortname}</option>
-                                </#list>
+                            <#if "${newUser!}"=="yes" || ("${newUser!}"=="no" && !user.email?ends_with("@humboldt.org.co"))>
+                                <#if restrictedResourcesForAllButIAvHUsers?has_content || restrictedResourcesForIAvHUsers?has_content >
+                                    <#list (restrictedResourcesForAllButIAvHUsers + restrictedResourcesForIAvHUsers)?sort_by("shortname") as rR>
+                                        <option value='${rR.shortname}'>${rR.shortname}</option>
+                                    </#list>
+                                </#if>
+                            </#if>
+                            <#if "${newUser!}"=="no" && user.email?ends_with("@humboldt.org.co") >
+                                <#if restrictedResourcesForIAvHUsers?has_content >
+                                    <#list restrictedResourcesForIAvHUsers?sort_by("shortname") as rR>
+                                        <option value='${rR.shortname}'>${rR.shortname}</option>
+                                    </#list>
+                                </#if>
                             </#if>
                         </select>
-                            <script type="text/javascript" charset="utf-8">
-                                $('#user\\.grantedAccessTo').multiSelect({
-                                    selectableHeader: "<div class='custom-header'><@s.text name="admin.user.restrictedResources" /></div>",
-                                    selectionHeader: "<div class='custom-header'><@s.text name="admin.user.grantAccessTo" /></div>"
-                                    });
-                                $('#user\\.grantedAccessTo').multiSelect('select', [
-                                    <#if user.grantedAccessTo?has_content >
-                                        ${ "'"+user.grantedAccessTo?split(", ")?join("', '")+"'" }
+
+                    <script type="text/javascript" charset="utf-8">
+                        $('#user\\.grantedAccessTo').multiSelect({
+                            selectableHeader: "<div class='custom-header'><@s.text name="admin.user.restrictedResources" /></div>",
+                            selectionHeader: "<div class='custom-header'><@s.text name="admin.user.grantAccessTo" /></div>"
+                        });
+                        $('#user\\.grantedAccessTo').multiSelect('select', [
+                            <#if user.grantedAccessTo?has_content >
+                                ${ "'"+user.grantedAccessTo?split(", ")?join("', '")+"'" }
+                            </#if>
+                            ]);
+
+                            <#if "${newUser!}"=="yes">
+                                $("input#user\\.email").on( "focusout", function(){
+                                if ($("input#user\\.email").val().endsWith("@humboldt.org.co")){
+                                    // Remove those restricted resources that are actually not restricted for @humboldt users
+                                    <#if restrictedResourcesForAllButIAvHUsers?has_content>
+                                        <#list restrictedResourcesForAllButIAvHUsers as rR>
+                                                $('#user\\.grantedAccessTo').find("option[value='${rR.shortname}']").remove();
+                                                $('#ms-user\\.grantedAccessTo').find("ul.ms-list li").filter(function() {
+                                                    return $(this).text() == "${rR.shortname}";
+                                                }).remove();
+                                        </#list>
                                     </#if>
-                                ]);
-                            </script>
-                            <div style="margin:auto; padding-top:10px; text-align: center;">
-                                <button type="button" cssClass="button" onClick="$('#user\\.grantedAccessTo').multiSelect('select_all');"><@s.text name="admin.user.grantAccessToAll" /></button>
-                                <button type="button" cssClass="button" onClick="$('#user\\.grantedAccessTo').multiSelect('deselect_all');"><@s.text name="admin.user.removeAccessToAll" /></button>
-                            </div>
-                            </br></br>
-                            
-                    </#if>
+                                } else { // The user to be created is not @humboldt.org.co, so refresh restricted resources lists
+                                    <#if restrictedResourcesForAllButIAvHUsers?has_content || restrictedResourcesForIAvHUsers?has_content >
+                                        <#list (restrictedResourcesForAllButIAvHUsers + restrictedResourcesForIAvHUsers) as rR>
+                                                $('#user\\.grantedAccessTo').find("option[value='${rR.shortname}']").remove();
+                                                $('#ms-user\\.grantedAccessTo').find("ul.ms-list li").filter(function() {
+                                                    return $(this).text() == "${rR.shortname}";
+                                                }).remove();
+                                        </#list>
+                                    </#if>
+                                    <#if restrictedResourcesForAllButIAvHUsers?has_content || restrictedResourcesForIAvHUsers?has_content >
+                                        <#list (restrictedResourcesForAllButIAvHUsers + restrictedResourcesForIAvHUsers)?sort_by("shortname") as rR>
+                                            $('#user\\.grantedAccessTo').multiSelect('addOption',{value:'${rR.shortname}',text:'${rR.shortname}'});
+                                        </#list>
+                                    </#if>
+                                }
+                                console.log("LISTO!!!");
+                                });
+                            </#if>
+                    </script>
+                    <div style="margin:auto; padding-top:10px; text-align: center;">
+                        <button type="button" cssClass="button" onClick="$('#user\\.grantedAccessTo').multiSelect('select_all');"><@s.text name="admin.user.grantAccessToAll" /></button>
+                        <button type="button" cssClass="button" onClick="$('#user\\.grantedAccessTo').multiSelect('deselect_all');"><@s.text name="admin.user.removeAccessToAll" /></button>
+                    </div>
+                    </br></br>
 
                 </div>
 

--- a/src/main/webapp/WEB-INF/pages/portal/resource_new.ftl
+++ b/src/main/webapp/WEB-INF/pages/portal/resource_new.ftl
@@ -291,33 +291,33 @@
 
         <#-- ...Testing... -->
         <#assign showDwCA=false/>
-        <#if eml.intellectualRights?has_content>
-        <#if elemInArray('Libre a nivel interno., Libre a nivel interno con notificación previa., Restringido temporalmente.', eml.intellectualRights, ", ") >
-                <h1 class="minuscular">Protegido!</h1>
-            <#if (Session.curr_user)??>
-                <#if Session.curr_user.email?ends_with("@humboldt.org.co") && eml.intellectualRights == "Libre a nivel interno." >
-					<#assign showDwCA=true/>
-				</#if>
-				<#if (Session.curr_user.email?ends_with("@humboldt.org.co") && eml.intellectualRights != "Libre a nivel interno.") || !Session.curr_user.email?ends_with("@humboldt.org.co") >
-					<#if Session.curr_user.grantedAccessTo?has_content >
-					    <h1 class="minuscular">(${resource.shortname}) --&gt; ${Session.curr_user.grantedAccessTo}</h1>
-						<#if elemInArray(Session.curr_user.grantedAccessTo, resource.shortname, ", ")>
-							<#assign showDwCA=true/>
-						<#else><h1 class="minuscular">Permiso denegado!</h1>
-				    </#if>
-				<#else>
-					<h1 class="minuscular">No se encontró 'grantedAccessTo'... </h1>
-				</#if>
-		    </#if>
-        <#else>
-            <h1 class="minuscular">Usuario invitado. </h1>
-        </#if>
+            <#if eml.intellectualRights?has_content>
+                <#if elemInArray('Libre a nivel interno., Libre a nivel interno con notificación previa., Restringido temporalmente.', eml.intellectualRights, ", ") >
+                    <h1 class="minuscular">Protegido!</h1>
+                    <#if (Session.curr_user)??>
+                         <#if Session.curr_user.email?ends_with("@humboldt.org.co") && eml.intellectualRights == "Libre a nivel interno." >
+					        <#assign showDwCA=true/>
+				        </#if>
+                        <#if (Session.curr_user.email?ends_with("@humboldt.org.co") && eml.intellectualRights != "Libre a nivel interno.") || !Session.curr_user.email?ends_with("@humboldt.org.co") >
+                            <#if Session.curr_user.grantedAccessTo?has_content >
+                                <h1 class="minuscular">(${resource.shortname}) --&gt; ${Session.curr_user.grantedAccessTo}</h1>
+                                <#if elemInArray(Session.curr_user.grantedAccessTo, resource.shortname, ", ")>
+                                    <#assign showDwCA=true/>
+                                <#else><h1 class="minuscular">Permiso denegado!</h1>
+                                </#if>
+                            <#else>
+                                <h1 class="minuscular">No se encontró 'grantedAccessTo'... </h1>
+                            </#if>
+                        </#if>
+                    <#else>
+                        <h1 class="minuscular">Usuario invitado. </h1>
+                    </#if>
+                 <#else>
+                    <#assign showDwCA=true/>
+                </#if>
             <#else>
                 <#assign showDwCA=true/>
             </#if>
-        <#else>
-            <#assign showDwCA=true/>
-        </#if>
 
         <#if showDwCA>
             <#if metadataOnly>
@@ -340,7 +340,7 @@
             </tr>
             </#if>
         </#if>
-                    <!-- /IAvH Customization-->
+        <!-- /IAvH Customization-->
 
         <#if metadataOnly != true>
             <div id="dataRecords" class="my-3 p-3 bg-body rounded shadow-sm">

--- a/src/main/webapp/WEB-INF/pages/portal/resource_new.ftl
+++ b/src/main/webapp/WEB-INF/pages/portal/resource_new.ftl
@@ -292,31 +292,29 @@
         <#-- ...Testing... -->
         <#assign showDwCA=false/>
         <#if eml.intellectualRights?has_content>
-        <#if eml.intellectualRights=='Libre a nivel interno.'><h1 class="minuscular">Protegido!</h1>
-            <#if (Session.curr_user)??>
-                <#if Session.curr_user.grantedAccessTo?has_content >
-                    <h1 class="minuscular">(${resource.shortname}) --&gt; ${Session.curr_user.grantedAccessTo}</h1>
-                    <#if elemInArray(Session.curr_user.grantedAccessTo, resource.shortname, ", ")>
-                        <#assign showDwCA=true/>
-                    <#else><h1 class="minuscular">Permiso denegado!</h1>
+            <#if eml.intellectualRights=='Libre a nivel interno.'><h1 class="minuscular">Protegido!</h1>
+                <#if (Session.curr_user)??>
+                    <#if Session.curr_user.grantedAccessTo?has_content >
+                        <h1 class="minuscular">(${resource.shortname}) --&gt; ${Session.curr_user.grantedAccessTo}</h1>
+                        <#if elemInArray(Session.curr_user.grantedAccessTo, resource.shortname, ", ")>
+                            <#assign showDwCA=true/>
+                        <#else><h1 class="minuscular">Permiso denegado!</h1>
+                        </#if>
+                    <#else>
+                        <h1 class="minuscular">No se encontró 'grantedAccessTo'... </h1>
                     </#if>
-                <#else>	
-                <h1 class="minuscular">No se encontró 'grantedAccessTo'... </h1>
+                <#else>
+                    <h1 class="minuscular">Usuario invitado. </h1>
                 </#if>
-            <#else>	
-                <h1 class="minuscular">Usuario invitado. </h1>
+            <#else>
+                <#assign showDwCA=true/>
             </#if>
-            <#else>	
+        <#else>
             <#assign showDwCA=true/>
-            </#if>	
-        <#else>	
-            <#assign showDwCA=true/>	
         </#if>
 
-        <#if showDwCA><h1 class="minuscular">Mostrar Enlace!!!</h1><#else><h1 class="minuscular">NO Mostrar Enlace!</h1></#if>
-
         <#if showDwCA>
-        <#if metadataOnly>
+            <#if metadataOnly>
             <#-- Archive, EML, and RTF download links include Google Analytics event tracking -->
             <#-- e.g. Archive event tracking includes components: _trackEvent method, category, action, label, (int) value -->
             <#-- EML and RTF versions can always be retrieved by version number but DWCA versions are only stored if IPT Archive Mode is on -->
@@ -334,6 +332,7 @@
                     </#if>
                 </td>
             </tr>
+            </#if>
         </#if>
                     <!-- /IAvH Customization-->
 


### PR DESCRIPTION
**Replicación del commit 15 de I2D Ceiba**
En este PR esta el commit **c0210a8** que se realiza para ajustar el problema de rama ceiba_master al listar los resultados sin estar logueado y seleccionar un recurso debido a duplicación de if en el archivo ftl src/main/webapp/WEB-INF/pages/portal/resource_new.ftl.

Estas son las notas del commit 15 (17 Marzo 2016):
Se ajusta el control de acceso a recursos restringidos los usuarios @humboldt.org.co tienen acceso a todos los recursos libres a nivel interno. El acceso a los restringidos temporalmente y los libres a nivel interno con notificación previa deben ser asignados manualmente por el admin. A los usuarios que no son @humboldt.org.co se les debe asignar permiso por parte del admin de forma manual. En el EDIT USER, en los listados de recursos restringidos se evita cargar libres a nivel interno para usuarios @humboldt.org.co, ya que esos no son restringidos para ellos. En el CREATE USER, en el evento lostfocus del input text user.email se actualiza el listado de recursos restringidos. La validación de descargas DwCA por parte del servidor también se ajustó, permitiendo a usuarios @humboldt.org.co la descarga de cualquier archivo libre a nivel interno. Para el resto de recursos restringidos se valida el archivo users.xml (etiqueta grantedAccessTo) contra el intellectualRights del recurso a descargar.