### PR TITLE
change license name to avoid select conflict

### DIFF
--- a/src/main/resources/ApplicationResources_es.properties
+++ b/src/main/resources/ApplicationResources_es.properties
@@ -1469,7 +1469,7 @@ eml.intellectualRights.nolicenses=No hay una licencia seleccionada
 eml.intellectualRights.license.disclaimer=Debe aplicar una licencia.
 eml.intellectualRights.license.text.externalInternal=Libre a nivel externo e interno
 eml.intellectualRights.license.text.internal=Libre a nivel interno
-eml.intellectualRights.license.text.internalNotification=Libre a nivel interno con notificación previa
+eml.intellectualRights.license.text.internalNotification=Libre en nivel interno con notificación previa
 eml.intellectualRights.license.text.temporalRestriction=Restringido temporalmente
 eml.intellectualRights.license.disclaimer=Debe aplicar la licencia CC0 solamente a su propio trabajo, a menos que tenga los derechos necesarios para aplicarla al trabajo de un tercero.
 

--- a/src/main/resources/org/gbif/metadata/eml/licenses.properties
+++ b/src/main/resources/org/gbif/metadata/eml/licenses.properties
@@ -7,7 +7,7 @@
 # To add a new license name, use the license.name.<prefix>=Name format
 license.name.ccbync=Libre a nivel interno y externo (Creative Commons Attribution Non Commercial (CC-BY-NC) 4.0)
 license.name.liiavh=Libre a nivel interno
-license.name.npiavh=Libre a nivel interno con notificaci\u00f3n previa
+license.name.npiavh=Libre en nivel interno con notificaci\u00f3n previa
 license.name.rt=Restringido temporalmente
 #license.name.pddl=Open Data Commons Public Domain Dedication and Licence (PDDL) 1.0
 #license.name.odcby=Open Data Commons Attribution License (ODC-By) 1.0
@@ -19,7 +19,7 @@ license.name.rt=Restringido temporalmente
 # Note: the HTML anchor is what enables the license to become machine-readable
 license.text.ccbync=La I2D podr\u00e1 compartir la informaci\u00f3n a entidades externas e investigadores del IAvH sin ninguna restricci\u00f3n. Licencia <a href="http://creativecommons.org/licenses/by-nc/4.0/legalcode">Libre a nivel interno y externo (Creative Commons Attribution Non Commercial (CC-BY-NC) 4.0)</a>.
 license.text.liiavh=La I2D podr\u00e1 compartir la informaci\u00f3n \u00fanicamente a investigadores del IAvH sin ninguna restricci\u00f3n. <a href="https://sites.google.com/humboldt.org.co/i2dwiki/licencia-i2d">Libre a nivel interno</a>.
-license.text.npiavh=La I2D podr\u00e1 compartir la informaci\u00f3n \u00fanicamente a investigadores del IAvH con previo aviso al investigador principal. <a href="https://sites.google.com/humboldt.org.co/i2dwiki/licencia-i2d">Libre a nivel interno con notificaci\u00f3n previa</a>.
+license.text.npiavh=La I2D podr\u00e1 compartir la informaci\u00f3n \u00fanicamente a investigadores del IAvH con previo aviso al investigador principal. <a href="https://sites.google.com/humboldt.org.co/i2dwiki/licencia-i2d">Libre en nivel interno con notificaci\u00f3n previa</a>.
 license.text.rt=La I2D se compromete a no compartir la informaci\u00f3n por un tiempo definido. El investigador principal debe determinar la fecha de liberaci\u00f3n para que la I2D pueda compartir la informaci\u00f3n. Despu\u00e9s de dicha fecha el tipo de acceso debe ser redefinido teniendo en cuenta los otros tipos de acceso. <a href="https://sites.google.com/humboldt.org.co/i2dwiki/licencia-i2d">Restringido temporalmente</a>.
 #license.text.pddl=This work is licensed under a <a href="http://www.opendatacommons.org/licenses/pddl/1.0">Open Data Commons Public Domain Dedication and Licence (PDDL) 1.0</a>.
 #license.text.odcby=This work is licensed under a <a href="http://www.opendatacommons.org/licenses/by/1.0">Open Data Commons Attribution License (ODC-By) 1.0</a>.

--- a/src/main/webapp/WEB-INF/pages/portal/resource_new.ftl
+++ b/src/main/webapp/WEB-INF/pages/portal/resource_new.ftl
@@ -120,7 +120,7 @@
     <#if eml.intellectualRights?has_content>
         <#if eml.intellectualRights.contains("Libre a nivel interno y externo") >
             <#assign showDwCA=true/>
-        <#elseif elemInArray('Libre a nivel interno, Libre a nivel interno con notificación previa, Restringido temporalmente', eml.intellectualRights, ", ")>
+        <#elseif elemInArray('Libre a nivel interno, Libre en nivel interno con notificación previa, Restringido temporalmente', eml.intellectualRights, ", ")>
             <#if (Session.curr_user)??>
                 <#if adminRights>
                     <#assign showDwCA=true/>>
@@ -331,7 +331,7 @@
                                             <a href="http://creativecommons.org/licenses/by-nc/4.0/legalcode" target="_blank">Libre a nivel interno y externo (Creative Commons Attribution Non Commercial (CC-BY-NC) 4.0)</a>
                                         <#elseif eml.intellectualRights.contains("Restringido temporalmente")>
                                             <a href="https://sites.google.com/humboldt.org.co/i2dwiki/licencia-i2d" target="_blank">Restringido temporalmente</a>
-                                        <#elseif eml.intellectualRights.contains("Libre a nivel interno con notificación previa")>
+                                        <#elseif eml.intellectualRights.contains("Libre en nivel interno con notificación previa")>
                                             <a href="https://sites.google.com/humboldt.org.co/i2dwiki/licencia-i2d" target="_blank">Libre a nivel interno con notificación previa</a>
                                         <#elseif eml.intellectualRights.contains("Libre a nivel interno")>
                                             <a href="https://sites.google.com/humboldt.org.co/i2dwiki/licencia-i2d" target="_blank">Libre a nivel interno</a>
@@ -488,7 +488,7 @@
                                     <a href="http://creativecommons.org/licenses/by-nc/4.0/legalcode" target="_blank">Libre a nivel interno y externo (Creative Commons Attribution Non Commercial (CC-BY-NC) 4.0)</a>
                                 <#elseif eml.intellectualRights.contains("Restringido temporalmente")>
                                     <a href="https://sites.google.com/humboldt.org.co/i2dwiki/licencia-i2d" target="_blank">Restringido temporalmente</a>
-                                <#elseif eml.intellectualRights.contains("Libre a nivel interno con notificación previa")>
+                                <#elseif eml.intellectualRights.contains("Libre en nivel interno con notificación previa")>
                                     <a href="https://sites.google.com/humboldt.org.co/i2dwiki/licencia-i2d" target="_blank">Libre a nivel interno con notificación previa</a>
                                 <#elseif eml.intellectualRights.contains("Libre a nivel interno")>
                                     <a href="https://sites.google.com/humboldt.org.co/i2dwiki/licencia-i2d" target="_blank">Libre a nivel interno</a>


### PR DESCRIPTION
Change the license name in properties files in order to avoid conflicts when license list options are displayed in the Edit Metadata View.